### PR TITLE
im.counters has argument userID, not username

### DIFF
--- a/api/rest-api/methods/im/counters.md
+++ b/api/rest-api/methods/im/counters.md
@@ -11,7 +11,7 @@ Gets counters of direct messages.
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `roomId` | `RtycPC29hqLJfT9xjew28FnZqipDpvKw3R` | Required | The id of Direct Messages' Room |
-| `username` | `RtycPC29hqLJfT9xj` | Optional | Counters for provided username \(need to have a view-room-administration right for calling user\) |
+| `userId` | `RtycPC29hqLJfT9xj` | Optional | Counters for provided user id \(need to have a view-room-administration right for calling user\) |
 
 ## Example Call
 


### PR DESCRIPTION
Similar to `groups.counters`