### PR TITLE
Users Endpoints (users.setStatus): add Content-type to example

### DIFF
--- a/reference/api/rest-api/endpoints/team-collaboration-endpoints/users-endpoints/set-status.md
+++ b/reference/api/rest-api/endpoints/team-collaboration-endpoints/users-endpoints/set-status.md
@@ -20,6 +20,7 @@ description: Sets a user Status when the status message and state is given.
 ```bash
 curl -H "X-Auth-Token: 40tB-Cn5YQJ74QMlQXi4Zf4E_-e0P5CrklU2pWOtV9M" \
      -H "X-User-Id: uunbZHiuEnib8Pawj" \
+     -H "Content-type: application/json" \
      -d '{"message":"My status update", "status": "online"}' \
      http://localhost:3000/api/v1/users.setStatus
 ```


### PR DESCRIPTION
The call `users.SetStatus` in [docs](https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/users-endpoints/set-status) is not working and was mentioned in [RocketChat Issue #19001](https://github.com/RocketChat/Rocket.Chat/issues/19001). It's necessary to add `Content-type` to make this call working.

This PR adds the right example to docs.