### PR TITLE
Fixed broken link to configuration accessor

### DIFF
--- a/apps-engine/fundamentals-of-apps/app-lifecycle.md
+++ b/apps-engine/fundamentals-of-apps/app-lifecycle.md
@@ -40,7 +40,7 @@ protected async extendConfiguration(configuration: IConfigurationExtend, environ
 }
 ```
 
-This method is executed as part of the default initialization process of the App. It enables the App to provide robust functionalities such as API Endpoints or Slash Commands using the [configuration accessor](https://rocketchat.github.io/Rocket.Chat.Apps-engine/interfaces/iconfigurationextend.html).
+This method is executed as part of the default initialization process of the App. It enables the App to provide robust functionalities such as API Endpoints or Slash Commands using the [configuration accessor](https://rocketchat.github.io/Rocket.Chat.Apps-engine/interfaces/accessors_iconfigurationextend.iconfigurationextend.html).
 
 ### `onEnable`
 


### PR DESCRIPTION
Fixes #87

I changed the link to https://rocketchat.github.io/Rocket.Chat.Apps-engine/interfaces/accessors_iconfigurationextend.iconfigurationextend.html because I think this will be the right link. 

Please review and do let me know if it is not the right one