### PR TITLE
Updated code in "Adding a Slashcommand" Section:

### DIFF
--- a/apps-engine/rocket.chat-app/creating-an-app.md
+++ b/apps-engine/rocket.chat-app/creating-an-app.md
@@ -231,7 +231,7 @@ For this example, create one. Now in this directory, create a file named `HelloW
 Enter the following line in the file.
 
 ```typescript
-import ISlashCommand from from "@rocket.chat/apps-engine/definition/slashcommands";
+import ISlashCommand from "@rocket.chat/apps-engine/definition/slashcommands";
 
 export class HelloWorldCommand implements ISlashCommand {}
 ```


### PR DESCRIPTION
<p>In the Rocket.chat Devs website, under Creating Your First App -> Adding a Slash Command, the code to be copied had the "from" keyword, written twice. It needed to be corrected.</p>

<strong>Screenshot of the issue:</strong>
![Screenshot from 2022-03-16 09-35-18](https://user-images.githubusercontent.com/90546860/158515594-8726e1c7-905e-4a6b-bbe0-504a1353671a.png)

