### PR TITLE
fix typo: Replace updatedSince with lastUpdate

### DIFF
--- a/reference/api/rest-api/endpoints/team-collaboration-endpoints/chat-endpoints/sync-messages.md
+++ b/reference/api/rest-api/endpoints/team-collaboration-endpoints/chat-endpoints/sync-messages.md
@@ -18,7 +18,7 @@ It supports the [Query, Fields](../../other-important-endpoints/query-and-fields
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `roomId` | `5qW6ssMFyzWjJev69` | Required | Room ID |
-| `updatedSince` | `2019-04-16T18:30:46.669Z` | Required | Date as ISO string |
+| `lastUpdate` | `2019-04-16T18:30:46.669Z` | Required | Date as ISO string |
 
 ## Example Call
 


### PR DESCRIPTION
The API call for Sync Message [here](https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/chat-endpoints/sync-messages) had some query parameter named incorrectly

It should be `lastUpdate` instead of `updatedSince`