### PR TITLE
Fix type in example URL

### DIFF
--- a/reference/api/rest-api/endpoints/core-endpoints/users-endpoints/set-preferences.md
+++ b/reference/api/rest-api/endpoints/core-endpoints/users-endpoints/set-preferences.md
@@ -2,7 +2,7 @@
 
 | URL                                    | Requires Auth | HTTP Method |
 | -------------------------------------- | ------------- | ----------- |
-| `/api/v1/users.saveUserPreferences.js` | `yes`         | `POST`      |
+| `/api/v1/users.saveUserPreferences` | `yes`         | `POST`      |
 
 ## Payload
 


### PR DESCRIPTION
The example URL previously ended with ".js", this pull request removes that typo.