### PR TITLE
Correcting the link to Rocket.Chat-Server Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ As a developer, you can
 
     Help in the development of:
 
-[RocketChat](https://developer.rocket.chat/rocket.chat/rocket.chat-server)
+[RocketChat](https://developer.rocket.chat/rocket.chat/rocket-chat-environment-setup)
 
 [Mobile App](https://developer.rocket.chat/mobile-app/mobile-app-environment-setup)
 


### PR DESCRIPTION
Corrected the link shown below, 
<img width="1552" alt="Screenshot 2022-08-09 at 12 52 42 PM" src="https://user-images.githubusercontent.com/73993394/183589855-3cd6db3c-fbb8-423c-983d-f9da5e7970a6.png">

Which was previously pointing to this wrong url :- (https://developer.rocket.chat/rocket.chat/rocket.chat-server)
<img width="1552" alt="Screenshot 2022-08-09 at 12 52 51 PM" src="https://user-images.githubusercontent.com/73993394/183589968-97702f32-5df5-4353-ad1c-138df1089f4d.png">

And now I've changed it to point to :- (https://developer.rocket.chat/rocket.chat/rocket-chat-environment-setup)
<img width="1552" alt="Screenshot 2022-08-09 at 12 52 57 PM" src="https://user-images.githubusercontent.com/73993394/183590218-0ba36832-a649-4da7-82c0-57da87cf5321.png">

