### PR TITLE
Typo on documentation

### DIFF
--- a/reference/api/rest-api/endpoints/core-endpoints/rooms-endpoints/change-archivation-state.md
+++ b/reference/api/rest-api/endpoints/core-endpoints/rooms-endpoints/change-archivation-state.md
@@ -6,7 +6,7 @@ description: Change the Archive state of a room.
 
 | URL                 | Requires Auth | HTTP Method |
 | ------------------- | ------------- | ----------- |
-| `/api/v1/rooms.get` | `yes`         | `POST`      |
+| `/api/v1/rooms.changeArchivationState` | `yes`         | `POST`      |
 
 ## Payload
 


### PR DESCRIPTION
Replaced `rooms.get` by `rooms.changeArchivationState`