### PR TITLE
macOS Installation Guide: Use direnv to ensure correct architecture

### DIFF
--- a/rocket.chat/rocket.chat-server/mac-osx.md
+++ b/rocket.chat/rocket.chat-server/mac-osx.md
@@ -43,16 +43,17 @@ You can set up and run a Rocket.Chat development environment on your macOS syste
 ```shell
 cd apps/meteor
 meteor --version
+cd ../..
 ```
 
-* Go back to the project root (`cd -`). Build and start your development server by executing
+* Build and start your development server by executing
 
 ```shell
 yarn build
 yarn dev # or yarn dsv if your system has less than 16 gigs of memory
 ```
 
-> If you face any issues, see the [troubleshoot](mac-osx.md#troubleshooting) section.
+> If you face any issues, see the [Troubleshooting](mac-osx.md#troubleshooting) section below.
 
 When done, you should see the following printed on your terminal and the local server running on `http://localhost:3000`
 
@@ -130,74 +131,81 @@ When done, you should see the following printed on your terminal and the local s
 
 ### 1. Command yarn failed with code 127 (Mac M1/2)
 
-If you face an error like the following
+If you face an error like the following:
 
-```
-➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 127, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-e2bec7de/build.log)
-➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 127, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-08c5a85c/build.log)
-➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 127, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-c7fa7b08/build.log)
-```
+    ```
+    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 127, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-e2bec7de/build.log)
+    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 127, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-08c5a85c/build.log)
+    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 127, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-c7fa7b08/build.log)
+    ```
 
-Run this command before running `yarn` again
+* Run this command
 
-```shell
-ln -sf $(which node) $(dirname $(which node))/nodejs
-```
+    ```shell
+    ln -sf $(which node) $(dirname $(which node))/nodejs
+    ```
+
+* Run `yarn` again
+
 
 ### 2. Fibers link failed (Mac M1/2)
 
-If `yarn` is failing on the link step for fibers with a log similar to
+If `yarn` is failing on the link step for fibers with a log similar to:
 
-```
-➤ YN0007: │ fibers@npm:5.0.3 must be built because it never has been before or the last one failed
-➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-7a9d15f1/build.log)
-➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-b359748c/build.log)
-➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-62becf57/build.log)
+    ```
+    ➤ YN0007: │ fibers@npm:5.0.3 must be built because it never has been before or the last one failed
+    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-7a9d15f1/build.log)
+    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-b359748c/build.log)
+    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-62becf57/build.log)
+    ```
 
-```
+* Install `node-gyp` globally
 
-Install `node-gyp` globally
+    ```shell
+    npm install node-gyp --global
+    ```
 
-```shell
-npm install node-gyp --global
-```
+* Rebuild fibers for the system architecture manually
 
-Rebuild fibers for the system architecture manually
+    ```shell
+    cd node_modules/fibers
+    node-gyp rebuild --arch=arm64
+    ```
 
-```shell
-cd node_modules/fibers && node-gyp rebuild --arch=arm64
-```
+* Copy binary to the correct location
 
-Move binary to the correct location
+    ```shell
+    mkdir bin/darwin-arm64-83
+    cp build/Release/fibers.node bin/darwin-arm64-83/fibers.node
+    ```
 
-```shell
-mkdir bin/darwin-arm64-83
-cp build/Release/fibers.node bin/darwin-arm64-83/fibers.node
-```
+* Copy the rebuilt module into meteor
 
-Share the directory
-
-```shell
-cd ../../ && cp -r node_modules/fibers apps/meteor/node_modules/
-```
+    ```shell
+    cd ../..
+    rm -rf apps/meteor/node_modules/fibers/
+    cp -r node_modules/fibers apps/meteor/node_modules/
+    ```
 
 ### 3. Bcrypt requires arm64 binary but has amd64 one (Mac M1/2)
 
-The error specifically looks like the following
+The error specifically looks like the following:
 
-```
-(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/bcrypt_lib.node' (no such file), '/usr/lib/bcrypt_lib.node' (no such file)
-```
+    ```
+    (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/bcrypt_lib.node' (no such file), '/usr/lib/bcrypt_lib.node' (no such file)
+    ```
 
-Move to the bcrypt directory and rebuild everything
+* Move to the bcrypt directory and rebuild everything
 
-```shell
-cd node_modules/bcrypt && 
+    ```shell
+    cd node_modules/bcrypt
     make
-```
+    ```
 
-Once build is succesfull, share the module
+* Copy the rebuilt module into meteor
 
-```shell
-cd ../.. && cp -r node_modules/bcrypt apps/meteor/node_modules/
-```
+    ```shell
+    cd ../..
+    rm -rf apps/meteor/node_modules/bcrypt
+    cp -r node_modules/bcrypt apps/meteor/node_modules/
+    ```

--- a/rocket.chat/rocket.chat-server/mac-osx.md
+++ b/rocket.chat/rocket.chat-server/mac-osx.md
@@ -7,15 +7,10 @@ You can set up and run a Rocket.Chat development environment on your macOS syste
 
 ## Apple Silicon
 
-{% hint style="info" %}
-* Node.js only has prebuilt binaries for [Apple Silicon](https://www.macworld.com/article/334279/apple-silicon-macs-may-be-a-reboot-of-the-g4-cube-and-colorful-imac-g3.html) as from `node v16`
-* Rocket.Chat currently uses at least `meteor 2.7.3` which has support for Apple silicon chips. If you are to run an environment with a lesser version, consider using[ the Rosetta terminal](https://support.apple.com/en-us/HT211861).
-{% endhint %}
 
 * Install node with [nvm](https://github.com/nvm-sh/nvm). Make sure the nvm version is >= 0.39.2
 * Install required nodejs version using nvm. You can check the current required version in the `package.json` file [here](https://github.com/RocketChat/Rocket.Chat/blob/develop/package.json#L42-L46).
 
-> For Apple Silicon, nvm (>= 0.39.2) will build nodejs from source if there is no official binary for the asked version (as of the time of this writing, this is the case for node 14.19.3)
 
 * Install yarn - read yarn's official documentation on [how to install yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable).
 * Install Meteor - read the official documentation on [how to install Meteor](https://docs.meteor.com/install.html).

--- a/rocket.chat/rocket.chat-server/mac-osx.md
+++ b/rocket.chat/rocket.chat-server/mac-osx.md
@@ -12,6 +12,7 @@ Note: If you face any issues, see the [Troubleshooting](mac-osx.md#troubleshooti
 {% endhint %}
 
 * Install [Homebrew](https://brew.sh/)
+<!-- direnv: Until RC upgrades to node 16, use meteor's node.
 * Install the [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm)
     ```shell
     brew install nvm
@@ -20,6 +21,7 @@ Note: If you face any issues, see the [Troubleshooting](mac-osx.md#troubleshooti
     ```shell
     nvm --version
     ```
+-->
 * [Fork the Rocket.Chat repository](https://github.com/RocketChat/Rocket.Chat/fork) into your own GitHub account
 * Clone your fork of the Rocket.Chat repository to your local dev box, navigate into the directory, and configure an additional remote so we can later fetch updates from the main Rocket.Chat repo
 
@@ -28,21 +30,33 @@ Note: If you face any issues, see the [Troubleshooting](mac-osx.md#troubleshooti
     cd Rocket.Chat
     git remote add upstream https://github.com/RocketChat/Rocket.Chat.git
     ```
+<!-- direnv: We will use meteor's node for now.
 * Find which version of node your version of RocketChat needs.
-    ```
+    ```shell
     cat package.json | grep -A4 engines | grep node
     ```
 * Install that version of node, _for example_:
-    ```
+    ```shell
     nvm install 14.19.3
     ```
+-->
 
+* Install the Meteor application framework
+    ```shell
+    curl https://install.meteor.com/ | sh
+    ```
 
-* Install yarn - read yarn's official documentation on [how to install yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable).
-* Install Meteor - read the official documentation on [how to install Meteor](https://docs.meteor.com/install.html).
+    This script will prompt you for your password in order to install `/usr/local/bin/meteor`.
 
+    {% hint style="info" %}
+    If in the future you wish to ***uninstall*** Meteor, run the commands:
+    ```shell
+    sudo rm /usr/local/bin/meteor
+    rm -rf ~/.meteor/
+    ```
+    {% endhint %}
 
-* Initialize the `meteor` framework.  This will show the version of meteor requested by Rocket.Chat
+* Initialize the Meteor framework.  This will show the version of meteor requested by Rocket.Chat
   (incidentally, specified in `apps/meteor/.meteor/release`) and will initialize it as a side-effect.
 
     ```shell
@@ -51,12 +65,52 @@ Note: If you face any issues, see the [Troubleshooting](mac-osx.md#troubleshooti
     cd ../..
     ```
 
+* Use `direnv` to help us maintain a custom development environment for Rocket.Chat.
+    * Install direnv
+        ```shell
+        brew install direnv
+        ```
+    * Enable direnv in your shell's rc file.  Follow the instructions at https://direnv.net/docs/hook.html and then restart your shell so it takes effect.
+    * Create a file in the Rocket.Chat folder called `.envrc` and add this line to it:
+        ```
+        PATH_add "$(meteor node -p 'require("path").dirname(process.execPath)')"
+        ```
+    * Activate the .envrc file
+        ```shell
+        direnv allow .
+        ```
+    * Find which version of node meteor is using
+        ```shell
+        meteor node --version
+        ```
+    * Edit `package.json` and change the listed node version to the one meteor is using.  Look for something like:
+        ```
+        "engines": {
+            "yarn": "3.2.2",
+            "node": "14.19.3",
+            "npm": "Use yarn instead"
+        },
+        ```
+        and change the "node" value to match the desired one.  Omit the leading "v" from the version number.
+
+* Install yarn
+    ```shell
+    npm install -g yarn
+    ```
+
+* Ensure we will build our packages clean slate
+    ```shell
+    rm -rf node_modules apps/meteor/node_modules
+    ```
+
 * Install all needed packages and build the Rocket.Chat app
 
     ```shell
     yarn
     yarn build
     ```
+
+    If you encounter problems (and at the time of writing, we expect you will), please see the [Troubleshooting](mac-osx.md#troubleshooting) section below and then try again.
 
 * Start your development server
 

--- a/rocket.chat/rocket.chat-server/mac-osx.md
+++ b/rocket.chat/rocket.chat-server/mac-osx.md
@@ -1,7 +1,6 @@
-# Mac OSX
+# macOS
 
-\
-You can set up and run a Rocket.Chat development environment on your Mac OSX.
+You can set up and run a Rocket.Chat development environment on your macOS system.
 
 * [Apple Silicon](mac-osx.md#apple-silicon)
 * [Non-Apple Silicon Chips](mac-osx.md#non-apple-silicon-chips)
@@ -45,7 +44,7 @@ yarn dev # or yarn dsv if your system has less than 16 gigs of memory
 
 When done, you should see the following printed on your terminal and the local server running on `http://localhost:3000`
 
-![Rocket.Chat server successfully running on MacOSX](<../../.gitbook/assets/image (51) (2).png>)
+![Rocket.Chat server successfully running on macOS](<../../.gitbook/assets/image (51) (2).png>)
 
 ## Non-Apple Silicon Chips
 
@@ -113,7 +112,7 @@ yarn dev
 
 When done, you should see the following printed on your terminal and the local server running on `http://localhost:3000`
 
-![Rocket.Chat server successfully running on MacOSX](<../../.gitbook/assets/image (51) (2).png>)
+![Rocket.Chat server successfully running on macOS](<../../.gitbook/assets/image (51) (2).png>)
 
 ## Troubleshooting
 

--- a/rocket.chat/rocket.chat-server/mac-osx.md
+++ b/rocket.chat/rocket.chat-server/mac-osx.md
@@ -129,34 +129,15 @@ When done, you should see the following printed on your terminal and the local s
 
 ## Troubleshooting
 
-### 1. Command yarn failed with code 127 (Mac M1/2)
-
-If you face an error like the following:
-
-    ```
-    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 127, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-e2bec7de/build.log)
-    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 127, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-08c5a85c/build.log)
-    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 127, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-c7fa7b08/build.log)
-    ```
-
-* Run this command
-
-    ```shell
-    ln -sf $(which node) $(dirname $(which node))/nodejs
-    ```
-
-* Run `yarn` again
-
-
-### 2. Fibers link failed (Mac M1/2)
+### 1. Failure linking "fibers" (Apple Silicon)
 
 If `yarn` is failing on the link step for fibers with a log similar to:
 
     ```
     ➤ YN0007: │ fibers@npm:5.0.3 must be built because it never has been before or the last one failed
-    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-7a9d15f1/build.log)
-    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-b359748c/build.log)
-    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/pq/xv5hx2d117jfxls2nx49wgrm0000gn/T/xfs-62becf57/build.log)
+    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/…/build.log)
+    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/…/build.log)
+    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/…/build.log)
     ```
 
 * Install `node-gyp` globally
@@ -187,7 +168,11 @@ If `yarn` is failing on the link step for fibers with a log similar to:
     cp -r node_modules/fibers apps/meteor/node_modules/
     ```
 
-### 3. Bcrypt requires arm64 binary but has amd64 one (Mac M1/2)
+* Follow the instructions below for fixing a Bcrypt problem, even though its error
+  message has not yet appeared.
+
+
+### 2. Bcrypt requires arm64 binary but has amd64 one instead (Apple Silicon)
 
 The error specifically looks like the following:
 

--- a/rocket.chat/rocket.chat-server/mac-osx.md
+++ b/rocket.chat/rocket.chat-server/mac-osx.md
@@ -150,12 +150,12 @@ When done, you should see the following printed on your terminal and the local s
 
 If `yarn` is failing on the link step for fibers with a log similar to:
 
-    ```
-    ➤ YN0007: │ fibers@npm:5.0.3 must be built because it never has been before or the last one failed
-    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/…/build.log)
-    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/…/build.log)
-    ➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/…/build.log)
-    ```
+```
+➤ YN0007: │ fibers@npm:5.0.3 must be built because it never has been before or the last one failed
+➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/…/build.log)
+➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/…/build.log)
+➤ YN0009: │ fibers@npm:5.0.3 couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/…/build.log)
+```
 
 * Install `node-gyp` globally
 
@@ -193,9 +193,9 @@ If `yarn` is failing on the link step for fibers with a log similar to:
 
 The error specifically looks like the following:
 
-    ```
-    (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/bcrypt_lib.node' (no such file), '/usr/lib/bcrypt_lib.node' (no such file)
-    ```
+```
+(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/bcrypt_lib.node' (no such file), '/usr/lib/bcrypt_lib.node' (no such file)
+```
 
 * Move to the bcrypt directory and rebuild everything
 

--- a/rocket.chat/rocket.chat-server/mac-osx.md
+++ b/rocket.chat/rocket.chat-server/mac-osx.md
@@ -7,6 +7,10 @@ You can set up and run a Rocket.Chat development environment on your macOS syste
 
 ## Apple Silicon
 
+{% hint style="info" %}
+Note: If you face any issues, see the [Troubleshooting](mac-osx.md#troubleshooting) section below.
+{% endhint %}
+
 * Install [Homebrew](https://brew.sh/)
 * Install the [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm)
     ```shell
@@ -38,22 +42,35 @@ You can set up and run a Rocket.Chat development environment on your macOS syste
 * Install Meteor - read the official documentation on [how to install Meteor](https://docs.meteor.com/install.html).
 
 
-* Run the following commands to navigate to the `meteor` directory to install the needed toolset, as configured in `.meteor/release` file
+* Initialize the `meteor` framework.  This will show the version of meteor requested by Rocket.Chat
+  (incidentally, specified in `apps/meteor/.meteor/release`) and will initialize it as a side-effect.
 
-```shell
-cd apps/meteor
-meteor --version
-cd ../..
-```
+    ```shell
+    cd apps/meteor
+    meteor --version
+    cd ../..
+    ```
 
-* Build and start your development server by executing
+* Install all needed packages and build the Rocket.Chat app
 
-```shell
-yarn build
-yarn dev # or yarn dsv if your system has less than 16 gigs of memory
-```
+    ```shell
+    yarn
+    yarn build
+    ```
 
-> If you face any issues, see the [Troubleshooting](mac-osx.md#troubleshooting) section below.
+* Start your development server
+
+    There are two ways to start the server.  For systems with >= 16 GB of memory, use
+
+    ```shell
+    yarn dev
+    ```
+
+    For systems with less than 16 GB of memory, use
+
+    ```shell
+    yarn dsv
+    ```
 
 When done, you should see the following printed on your terminal and the local server running on `http://localhost:3000`
 

--- a/rocket.chat/rocket.chat-server/mac-osx.md
+++ b/rocket.chat/rocket.chat-server/mac-osx.md
@@ -7,19 +7,36 @@ You can set up and run a Rocket.Chat development environment on your macOS syste
 
 ## Apple Silicon
 
+* Install [Homebrew](https://brew.sh/)
+* Install the [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm)
+    ```shell
+    brew install nvm
+    ```
+  * Important!  Make sure you are running nvm version >= 0.39.2
+    ```shell
+    nvm --version
+    ```
+* [Fork the Rocket.Chat repository](https://github.com/RocketChat/Rocket.Chat/fork) into your own GitHub account
+* Clone your fork of the Rocket.Chat repository to your local dev box, navigate into the directory, and configure an additional remote so we can later fetch updates from the main Rocket.Chat repo
 
-* Install node with [nvm](https://github.com/nvm-sh/nvm). Make sure the nvm version is >= 0.39.2
-* Install required nodejs version using nvm. You can check the current required version in the `package.json` file [here](https://github.com/RocketChat/Rocket.Chat/blob/develop/package.json#L42-L46).
+    ```shell
+    git clone https://github.com/your-username/Rocket.Chat
+    cd Rocket.Chat
+    git remote add upstream https://github.com/RocketChat/Rocket.Chat.git
+    ```
+* Find which version of node your version of RocketChat needs.
+    ```
+    cat package.json | grep -A4 engines | grep node
+    ```
+* Install that version of node, _for example_:
+    ```
+    nvm install 14.19.3
+    ```
 
 
 * Install yarn - read yarn's official documentation on [how to install yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable).
 * Install Meteor - read the official documentation on [how to install Meteor](https://docs.meteor.com/install.html).
-* Fork and clone the [Rocket.Chat repository](https://github.com/RocketChat/Rocket.Chat) and navigate into the directory
 
-```shell
-git clone https://github.com/your-username/Rocket.Chat
-cd Rocket.Chat
-```
 
 * Run the following commands to navigate to the `meteor` directory to install the needed toolset, as configured in `.meteor/release` file
 


### PR DESCRIPTION
Debdut advised me to use `direnv` and meteor's node installation rather than `nvm` and RC's package.json-specified node version.  I've codified his instructions into the doc.

Note that this PR builds upon my earlier one (#148), so only the final commit ([Use direnv to enforce using meteor's node installation](https://github.com/RocketChat/developer-docs/pull/149/commits/ea322528c57b1e947a57863fca64aafd073f84a1)) is specific to this PR.