### PR TITLE
Add `npx react-native start`

### DIFF
--- a/mobile-app/mobile-app-environment-setup/README.md
+++ b/mobile-app/mobile-app-environment-setup/README.md
@@ -30,13 +30,18 @@ yarn
 
 Run the app:
 
+for _iOs_:
 ```
 npx pod-install
 yarn ios
 ```
 
-or
+or, for _android_:
 
+```
+npx react-native start
+```
+_and in a separate terminal:_
 ```
 yarn android
 ```


### PR DESCRIPTION
App won't run on emulator without a running metro instance. Took me a day to find out, maybe helpful for other newbies like me.