### PR TITLE
[FIX] Changing "yarn dev" to "yarn dsv"

### DIFF
--- a/rocket.chat/rocket-chat-environment-setup/linux.md
+++ b/rocket.chat/rocket-chat-environment-setup/linux.md
@@ -100,7 +100,7 @@ meteor --version
 * Build and startup your development server by executing the commands below. Building for the first time will take a while and you may see some warnings or errors.
 
 ```bash
-yarn dev
+yarn dsv
 ```
 
 When the server is ready, you will see a box with "Server Running" title:


### PR DESCRIPTION
Tried `yarn dev` to start the server, it didn't work but `yarn dsv` worked and it is also the suggested way to spin the server in the README file of RocketChat/Rocket.Chat
I'm not sure this should be done or not, but if it's accepted, I'll change this in all the required places.