### PR TITLE
Add `excludeSelf` param to `groups.create` and `channels.create` endpoints

### DIFF
--- a/reference/api/rest-api/endpoints/rooms/channels-endpoints/create.md
+++ b/reference/api/rest-api/endpoints/rooms/channels-endpoints/create.md
@@ -19,7 +19,7 @@ This can be modified in the **Admin** > **General** > **UTF8**. Channel names sh
 | `name`     | `channelname`    | Required                  | The name of the new channel                         |
 | `members`  | `["rocket.cat"]` | Optional Default: `[]`    | The users to add to the channel when it is created. |
 | `readOnly` | `true`           | Optional Default: `false` | Set if the channel is read only or not.             |
-| `excludeSelf` | `true`        | Optional Default: `false` | If set to `true` the user calling the endpoint is automatically not added as a member of the group. |
+| `excludeSelf` | `true`        | Optional Default: `false` | If set to `true` the user calling the endpoint is not automatically added as a member of the group. |
 
 ## Example Call
 

--- a/reference/api/rest-api/endpoints/rooms/channels-endpoints/create.md
+++ b/reference/api/rest-api/endpoints/rooms/channels-endpoints/create.md
@@ -19,6 +19,7 @@ This can be modified in the **Admin** > **General** > **UTF8**. Channel names sh
 | `name`     | `channelname`    | Required                  | The name of the new channel                         |
 | `members`  | `["rocket.cat"]` | Optional Default: `[]`    | The users to add to the channel when it is created. |
 | `readOnly` | `true`           | Optional Default: `false` | Set if the channel is read only or not.             |
+| `excludeSelf` | `true`        | Optional Default: `false` | If set to `true` the user calling the endpoint is automatically not added as a member of the group. |
 
 ## Example Call
 
@@ -56,4 +57,5 @@ curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
 
 | Version | Description |
 | ------- | ----------- |
+| 6.4.1   | Added `excludeSelf` param |
 | 0.13.0  | Added       |

--- a/reference/api/rest-api/endpoints/rooms/groups-endpoints/create.md
+++ b/reference/api/rest-api/endpoints/rooms/groups-endpoints/create.md
@@ -13,7 +13,7 @@ Creates a new private group, optionally including specified users. The group cre
 | `name`     | `testing`        | Required                  | The name of the new private group                 |
 | `members`  | `["rocket.cat"]` | Optional Default: `[]`    | The users to add to the group when it is created. |
 | `readOnly` | `true`           | Optional Default: `false` | Set if the group is read only or not.             |
-| `excludeSelf` | `true`           | Optional Default: `false` | If set to `true` the user calling the endpoint is automatically not added as a member of the group. |
+| `excludeSelf` | `true`        | Optional Default: `false` | If set to `true` the user calling the endpoint is automatically not added as a member of the group. |
 
 ## Example Call
 

--- a/reference/api/rest-api/endpoints/rooms/groups-endpoints/create.md
+++ b/reference/api/rest-api/endpoints/rooms/groups-endpoints/create.md
@@ -13,7 +13,7 @@ Creates a new private group, optionally including specified users. The group cre
 | `name`     | `testing`        | Required                  | The name of the new private group                 |
 | `members`  | `["rocket.cat"]` | Optional Default: `[]`    | The users to add to the group when it is created. |
 | `readOnly` | `true`           | Optional Default: `false` | Set if the group is read only or not.             |
-| `excludeSelf` | `true`        | Optional Default: `false` | If set to `true` the user calling the endpoint is automatically not added as a member of the group. |
+| `excludeSelf` | `true`        | Optional Default: `false` | If set to `true` the user calling the endpoint is not automatically added as a member of the group. |
 
 ## Example Call
 

--- a/reference/api/rest-api/endpoints/rooms/groups-endpoints/create.md
+++ b/reference/api/rest-api/endpoints/rooms/groups-endpoints/create.md
@@ -13,6 +13,7 @@ Creates a new private group, optionally including specified users. The group cre
 | `name`     | `testing`        | Required                  | The name of the new private group                 |
 | `members`  | `["rocket.cat"]` | Optional Default: `[]`    | The users to add to the group when it is created. |
 | `readOnly` | `true`           | Optional Default: `false` | Set if the group is read only or not.             |
+| `excludeSelf` | `true`           | Optional Default: `false` | If set to `true` the user calling the endpoint is automatically not added as a member of the group. |
 
 ## Example Call
 
@@ -50,4 +51,5 @@ curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
 
 | Version | Description |
 | ------- | ----------- |
+| 6.4.1   | Added `excludeSelf` param |
 | 0.35.0  | Added       |


### PR DESCRIPTION
The new param was added on Rocket.Chat version 6.4.1